### PR TITLE
Makes non-continuous BW display available, works for +/- values

### DIFF
--- a/js/View/Track/MultiWiggle/MultiXYPlot.js
+++ b/js/View/Track/MultiWiggle/MultiXYPlot.js
@@ -96,35 +96,46 @@ return declare( [WiggleBase, YScaleMixin],
                 var f = s['feat'];
                 var source = f.get('source');
                 if( score <= canvasHeight || score > originY) { // if the rectangle is visible at all
+                    var nonCont = this.config.urlTemplates[this.map[source]].nonCont;
                     if( score <= originY ) {
                         // bar goes upward
-                    
-                       // this.getConfForFeature('style.pos_color',f);
-                        //thisB._fillRectMod( context, i, score, 1, 1);
-                        context.beginPath();
-                        context.strokeStyle = this.config.urlTemplates[this.map[source]].color;
-                        var x = (map[source]||{}).x || i;
-                        var y = (map[source]||{}).y || score;
-                        if(i==x+1) {
-                            context.moveTo(x, y);
-                            context.lineTo(i,score);
-                        }
-                        else if(i==x&&i!=0) {
-                            context.moveTo(x-1, canvasHeight);
-                            context.lineTo(x,score);
+                        if(nonCont) {
+                          context.fillStyle = this.config.urlTemplates[this.map[source]].color;
+                          thisB._fillRectMod( context, i, score, 1, 1);
                         }
                         else {
-                            context.moveTo(x,y);
-                            context.lineTo(x+1,canvasHeight);
-                            context.lineTo(i-1,canvasHeight);
-                            context.lineTo(i,score);
+                          context.strokeStyle = this.config.urlTemplates[this.map[source]].color;
+                          context.beginPath();
+                          var x = (map[source]||{}).x || i;
+                          var y = (map[source]||{}).y || score;
+                          if(i==x+1) {
+                              context.moveTo(x, y);
+                              context.lineTo(i,score);
+                          }
+                          else if(i==x&&i!=0) {
+                              context.moveTo(x-1, canvasHeight);
+                              context.lineTo(x,score);
+                          }
+                          else {
+                              context.moveTo(x,y);
+                              context.lineTo(x+1,canvasHeight);
+                              context.lineTo(i-1,canvasHeight);
+                              context.lineTo(i,score);
+                          }
+                          context.stroke();
+                          map[source] = {x: i, y: score};
                         }
-                        context.stroke();
-                        map[source] = {x: i, y: score};
+                    }
+                    else {
+                      //negative values
+                      if(nonCont) {
+                        context.fillStyle = this.config.urlTemplates[this.map[source]].color;
+                        thisB._fillRectMod( context, i, score-1, 1,  1);
+                      }
                     }
                 }
             }, this );
-            
+
         }, this );
     }
 });


### PR DESCRIPTION
I've added the equivalent of the noFill option as a `nonCont` option, works for negative values too:

<img width="595" alt="screen shot 2016-06-02 at 21 16 48" src="https://cloud.githubusercontent.com/assets/3740323/15759736/f07d7c5c-2907-11e6-9d3c-73b19b6d9a3a.png">

(a few artefacts in the original continuous MultiXYPlot, missing verticals can be seen in screenshot).

Modification to config is trivial:
`{"url":"tracks/1.bw","name":"1", "color": "red", "nonCont": true}`

I did have a little poke at modifying the existing continuous XYPlot to support negative values but didn't get too far, I couldn't figure out how to prevent the pos plot from starting at the base of the plot rather than 0:

<img width="188" alt="screen shot 2016-06-02 at 21 26 58" src="https://cloud.githubusercontent.com/assets/3740323/15759940/f0d607d6-2908-11e6-87d4-aa5921cf541d.png">
