### PR TITLE
Extend further to allow filled non continuous

### DIFF
--- a/js/View/Track/MultiWiggle/MultiXYPlot.js
+++ b/js/View/Track/MultiWiggle/MultiXYPlot.js
@@ -101,7 +101,11 @@ return declare( [WiggleBase, YScaleMixin],
                         // bar goes upward
                         if(nonCont) {
                           context.fillStyle = this.config.urlTemplates[this.map[source]].color;
-                          thisB._fillRectMod( context, i, score, 1, 1);
+                          var height = 1
+                          if(this.config.urlTemplates[this.map[source]].fill == true) {
+                            height = originY-score+1;
+                          }
+                          thisB._fillRectMod( context, i, score, 1, height);
                         }
                         else {
                           context.strokeStyle = this.config.urlTemplates[this.map[source]].color;
@@ -130,7 +134,16 @@ return declare( [WiggleBase, YScaleMixin],
                       //negative values
                       if(nonCont) {
                         context.fillStyle = this.config.urlTemplates[this.map[source]].color;
-                        thisB._fillRectMod( context, i, score-1, 1,  1);
+
+                        var top = score-1;
+                        var height = 1;
+                        if(this.config.urlTemplates[this.map[source]].fill == true) {
+                          top = originY;
+                          height = score-originY;
+                        }
+                        thisB._fillRectMod( context, i, top, 1,  height);
+
+
                       }
                     }
                 }


### PR DESCRIPTION
Looks like you've already merged, but heres an extension to allow filled layers:

<img width="539" alt="screen shot 2016-06-03 at 21 35 37" src="https://cloud.githubusercontent.com/assets/3740323/15792174/847a2ff6-29d3-11e6-9b94-16977273d553.png">

<img width="534" alt="screen shot 2016-06-03 at 21 38 40" src="https://cloud.githubusercontent.com/assets/3740323/15792183/934dbfd4-29d3-11e6-9850-a5e1a760134c.png">

Just add `"fill": true` to the relevant urlTemplate line.